### PR TITLE
Update Readme/Credits, Initial Color Bulb Support, 403 Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
-# homebridge-wyze-connected-home
+# homebridge-wyze-connected-home-op
 ## Releases
+
+### v0.5.4
+- Initial support for new Wyze Color Bulbs
+- Added a user agent for login request to prevent 403 error
 
 ### v0.5.3
 - Improve logfile output for Bulb and Outdoor Plug

--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
-# homebridge-wyze-connected-home
+# homebridge-wyze-connected-home-op
 
 This plugin adds support for Wyze Connected Home devices to [Homebridge](https://github.com/homebridge/homebridge).
 
+This plugin is an actively maintained fork of misenhower's original [Wyze Homebridge Plugin](https://github.com/misenhower/homebridge-wyze-connected-home) project.
+
 ## Supported Devices
 - Light Bulb
+- Color Bulb (Mesh Light)
 - Plug
 - Outdoor Plug
 - V1 Contact Sensor
@@ -39,8 +42,8 @@ Supported devices will be discovered and added to Homebridge automatically.
 
 ## Other Info
 
-Special thanks to the following projects for reference and inspiration:
-* **[ha-wyzeapi](https://github.com/JoshuaMulliken/ha-wyzeapi)**, a Wyze integration for Home Assistant
-* **[wyze-node](https://github.com/noelportugal/wyze-node)**, a Node library for the Wyze API
+Thanks to [misenhower](https://github.com/misenhower/homebridge-wyze-connected-home) and [contributors](https://github.com/misenhower/homebridge-wyze-connected-home/graphs/contributors) for the original Wyze Homebridge plugin and volunteering their time to help add support for more devices and features.
 
-Also, thanks to the [contributors](https://github.com/misenhower/homebridge-wyze-connected-home/graphs/contributors) who volunteered their time to help add support for more devices and features.
+Thanks to [mda590](https://github.com/misenhower/homebridge-wyze-connected-home/pull/35) for initial Color Bulb support.
+
+Thanks to [Chew](https://github.com/misenhower/homebridge-wyze-connected-home/pull/40) for adding a user agent for login request to prevent 403 errors.

--- a/README.md
+++ b/README.md
@@ -43,8 +43,9 @@ Supported devices will be discovered and added to Homebridge automatically.
 ## Other Info
 
 Special thanks to the following projects for reference and inspiration:
-[ha-wyzeapi](https://github.com/JoshuaMulliken/ha-wyzeapi), a Wyze integration for Home Assistant.
-[wyze-node](https://github.com/noelportugal/wyze-node), a Node library for the Wyze API.
+
+- [ha-wyzeapi](https://github.com/JoshuaMulliken/ha-wyzeapi), a Wyze integration for Home Assistant.
+- [wyze-node](https://github.com/noelportugal/wyze-node), a Node library for the Wyze API.
 
 Thanks to [misenhower](https://github.com/misenhower/homebridge-wyze-connected-home) and [contributors](https://github.com/misenhower/homebridge-wyze-connected-home/graphs/contributors) for the original Wyze Homebridge plugin and volunteering their time to help add support for more devices and features.
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ Supported devices will be discovered and added to Homebridge automatically.
 
 ## Other Info
 
+Special thanks to the following projects for reference and inspiration:
+[ha-wyzeapi](https://github.com/JoshuaMulliken/ha-wyzeapi), a Wyze integration for Home Assistant
+[wyze-node](https://github.com/noelportugal/wyze-node), a Node library for the Wyze API
+
 Thanks to [misenhower](https://github.com/misenhower/homebridge-wyze-connected-home) and [contributors](https://github.com/misenhower/homebridge-wyze-connected-home/graphs/contributors) for the original Wyze Homebridge plugin and volunteering their time to help add support for more devices and features.
 
 Thanks to [mda590](https://github.com/misenhower/homebridge-wyze-connected-home/pull/35) for initial Color Bulb support.

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ Supported devices will be discovered and added to Homebridge automatically.
 ## Other Info
 
 Special thanks to the following projects for reference and inspiration:
-[ha-wyzeapi](https://github.com/JoshuaMulliken/ha-wyzeapi), a Wyze integration for Home Assistant
-[wyze-node](https://github.com/noelportugal/wyze-node), a Node library for the Wyze API
+[ha-wyzeapi](https://github.com/JoshuaMulliken/ha-wyzeapi), a Wyze integration for Home Assistant.
+[wyze-node](https://github.com/noelportugal/wyze-node), a Node library for the Wyze API.
 
 Thanks to [misenhower](https://github.com/misenhower/homebridge-wyze-connected-home) and [contributors](https://github.com/misenhower/homebridge-wyze-connected-home/graphs/contributors) for the original Wyze Homebridge plugin and volunteering their time to help add support for more devices and features.
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "homebridge": ">=0.2.0"
   },
   "dependencies": {
-    "axios": "^0.19.2",
+    "axios": "^0.21.1",
     "colorsys": "^1.0.22",
     "md5": "^2.2.1"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-wyze-connected-home-op",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "Wyze Connected Home plugin for Homebridge",
   "license": "MIT",
   "main": "src/index.js",
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "axios": "^0.19.2",
+    "colorsys": "^1.0.22",
     "md5": "^2.2.1"
   },
   "devDependencies": {

--- a/src/WyzeAPI.js
+++ b/src/WyzeAPI.js
@@ -21,10 +21,11 @@ module.exports = class WyzeAPI {
     this.authApiKey = options.authApiKey || 'WMXHYf79Nr5gIlt3r0r7p9Tcw5bvs6BB4U8O8nGJ';
     this.phoneId = options.phoneId || 'bc151f39-787b-4871-be27-5a20fd0a1937';
     this.appName = options.appName || 'com.hualai.WyzeCam';
-    this.appVer = options.appVer || 'com.hualai.WyzeCam___2.10.72';
-    this.appVersion = options.appVersion || '2.10.72';
+    this.appVer = options.appVer || 'com.hualai.WyzeCam___2.18.44';
+    this.appVersion = options.appVersion || '2.18.44';
     this.sc = '9f275790cab94a72bd206c8876429f3c';
     this.sv = '9d74946e652647e9b6c9d59326aef104';
+    this.userAgent = options.userAgent || "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1 Safari/605.1.15";
 
     // Login tokens
     this.access_token = '';
@@ -118,7 +119,7 @@ module.exports = class WyzeAPI {
 
     const config = {
       baseURL: this.authBaseUrl,
-      headers: { 'x-api-key': this.authApiKey },
+      headers: { 'x-api-key': this.authApiKey, "User-Agent": this.userAgent },
     };
 
     return this._performRequest(url, data, config);
@@ -225,6 +226,47 @@ module.exports = class WyzeAPI {
     };
 
     const result = await this.request('app/v2/device/set_property', data);
+
+    return result.data;
+  }
+
+  async runActionList(deviceMac, deviceModel, propertyId, propertyValue) {
+    // Wyze Color Bulbs use a new run_action_list endpoint instead of set_property
+    const plist = [
+      {
+        pid: propertyId,
+        pvalue: String(propertyValue),
+      }
+    ];
+    if (propertyId != "P3") {
+      plist.push({
+        pid: "P3",
+        pvalue: "1",
+      })
+    };
+    const innerList = [
+      {
+        mac: deviceMac,
+        plist: plist,
+      }
+    ];
+    const actionParams = {
+      list: innerList,
+    };
+    const actionList = [
+      {
+        instance_id: deviceMac,
+        action_params: actionParams,
+        provider_key: deviceModel,
+        action_key: "set_mesh_property",
+      }
+    ];
+    const data = {
+      action_list: actionList,
+    };
+    this.log.debug(`run_action_list Data Body: ${JSON.stringify(data)}`);
+
+    const result = await this.request('app/v2/auto/run_action_list', data);
 
     return result.data;
   }

--- a/src/WyzeConnectedHome.js
+++ b/src/WyzeConnectedHome.js
@@ -2,6 +2,7 @@ const { homebridge, Accessory, UUIDGen } = require('./types');
 const WyzeAPI = require('./WyzeAPI');
 const WyzePlug = require('./accessories/WyzePlug');
 const WyzeLight = require('./accessories/WyzeLight');
+const WyzeMeshLight = require('./accessories/WyzeMeshLight');
 const WyzeContactSensor = require('./accessories/WyzeContactSensor');
 const WyzeMotionSensor = require('./accessories/WyzeMotionSensor');
 
@@ -120,6 +121,8 @@ module.exports = class WyzeConnectedHome {
         return WyzePlug;
       case 'Light':
         return WyzeLight;
+      case 'MeshLight':
+        return WyzeMeshLight;
       case 'ContactSensor':
         return WyzeContactSensor;
       case 'MotionSensor':

--- a/src/accessories/WyzeAccessory.js
+++ b/src/accessories/WyzeAccessory.js
@@ -85,4 +85,15 @@ module.exports = class WyzeAccessory {
       this.updating = false;
     }
   }
+  async runActionList(property, value) {
+    try {
+      this.updating = true;
+
+      let response = await this.plugin.client.runActionList(this.mac, this.product_model, property, value);
+
+      this.lastTimestamp = response.ts;
+    } finally {
+      this.updating = false;
+    }
+  }
 };

--- a/src/accessories/WyzeMeshLight.js
+++ b/src/accessories/WyzeMeshLight.js
@@ -1,0 +1,186 @@
+const colorsys = require('colorsys')
+const { Service, Characteristic } = require('../types');
+const WyzeAccessory = require('./WyzeAccessory');
+
+const WYZE_API_POWER_PROPERTY = 'P3';
+const WYZE_API_BRIGHTNESS_PROPERTY = 'P1501';
+const WYZE_API_COLOR_TEMP_PROPERTY = 'P1502';
+const WYZE_API_COLOR_PROPERTY = 'P1507';
+
+const WYZE_COLOR_TEMP_MIN = 1800;
+const WYZE_COLOR_TEMP_MAX = 6500;
+const HOMEKIT_COLOR_TEMP_MIN = 500;
+const HOMEKIT_COLOR_TEMP_MAX = 140;
+
+module.exports = class WyzeMeshLight extends WyzeAccessory {
+  constructor(plugin, homeKitAccessory) {
+    super(plugin, homeKitAccessory);
+
+    this.getCharacteristic(Characteristic.On).on('set', this.setOn.bind(this));
+    this.getCharacteristic(Characteristic.Brightness).on('set', this.setBrightness.bind(this));
+    this.getCharacteristic(Characteristic.ColorTemperature).on('set', this.setColorTemperature.bind(this));
+    this.getCharacteristic(Characteristic.Hue).on('set', this.setHue.bind(this));
+    this.getCharacteristic(Characteristic.Saturation).on('set', this.setSaturation.bind(this));
+
+    // Local caching of HSV color space handling separate Hue & Saturation on HomeKit
+    // Caching idea for handling HSV colors from:
+    //    https://github.com/QuickSander/homebridge-http-rgb-push/blob/master/index.js
+    this.cache = {};
+    this.cacheUpdated = false;
+  }
+
+  async updateCharacteristics(device) {
+    this.getCharacteristic(Characteristic.On).updateValue(device.device_params.switch_state);
+
+    let propertyList = await this.getPropertyList();
+    for (let property of propertyList.data.property_list) {
+      switch (property.pid) {
+        case WYZE_API_BRIGHTNESS_PROPERTY:
+          this.updateBrightness(property.value);
+          break;
+
+        case WYZE_API_COLOR_TEMP_PROPERTY:
+          this.updateColorTemp(property.value);
+          break;
+
+        case WYZE_API_COLOR_PROPERTY:
+          this.updateColor(property.value);
+          break;
+      }
+    }
+  }
+
+  updateBrightness(value) {
+    this.getCharacteristic(Characteristic.Brightness).updateValue(value);
+  }
+
+  updateColorTemp(value) {
+    let floatValue = this._rangeToFloat(value, WYZE_COLOR_TEMP_MIN, WYZE_COLOR_TEMP_MAX);
+    let homeKitValue = this._floatToRange(floatValue, HOMEKIT_COLOR_TEMP_MIN, HOMEKIT_COLOR_TEMP_MAX);
+    this.getCharacteristic(Characteristic.ColorTemperature).updateValue(homeKitValue);
+  }
+
+  updateColor(value) {
+    // Convert a Hex color from Wyze into the HSL values recognized by HomeKit.
+    let hslValue = colorsys.hex2Hsv(value);
+    this.plugin.log.debug(`Updating color record for ${this.homeKitAccessory.context.mac} to ${value}: ${JSON.stringify(hslValue)}`)
+
+    // Update Hue
+    this.updateHue(hslValue.h);
+    this.cache.hue = hslValue.h;
+
+    // Update Saturation
+    this.updateSaturation(hslValue.s);
+    this.cache.saturation = hslValue.s;
+  }
+
+  updateHue(value) {
+    this.getCharacteristic(Characteristic.Hue).updateValue(value);
+  }
+
+  updateSaturation(value) {
+    this.getCharacteristic(Characteristic.Saturation).updateValue(value);
+  }
+
+  getService() {
+    let service = this.homeKitAccessory.getService(Service.Lightbulb);
+
+    if (!service) {
+      service = this.homeKitAccessory.addService(Service.Lightbulb);
+    }
+
+    return service;
+  }
+
+  getCharacteristic(characteristic) {
+    return this.getService().getCharacteristic(characteristic);
+  }
+
+  async setOn(value, callback) {
+    this.plugin.log.info(`Setting power for ${this.homeKitAccessory.context.mac} to ${value}`);
+
+    try {
+      await this.runActionList(WYZE_API_POWER_PROPERTY, (value) ? '1' : '0');
+      callback();
+    } catch (e) {
+      callback(e);
+    }
+  }
+
+  async setBrightness(value, callback) {
+    this.plugin.log.info(`Setting brightness for ${this.homeKitAccessory.context.mac} to ${value}`);
+
+    try {
+      await this.runActionList(WYZE_API_BRIGHTNESS_PROPERTY, value);
+      callback();
+    } catch (e) {
+      callback(e);
+    }
+  }
+
+  async setColorTemperature(value, callback) {
+    let floatValue = this._rangeToFloat(value, HOMEKIT_COLOR_TEMP_MIN, HOMEKIT_COLOR_TEMP_MAX);
+    let wyzeValue = this._floatToRange(floatValue, WYZE_COLOR_TEMP_MIN, WYZE_COLOR_TEMP_MAX);
+
+    this.plugin.log.info(`Setting color temperature for ${this.homeKitAccessory.context.mac} to ${value} (${wyzeValue})`);
+
+    try {
+      await this.runActionList(WYZE_API_COLOR_TEMP_PROPERTY, wyzeValue);
+      callback();
+    } catch (e) {
+      callback(e);
+    }
+  }
+
+  async setHue(value, callback) {
+    this.plugin.log.info(`Setting hue (color) for ${this.homeKitAccessory.context.mac} to ${value}`);
+    this.plugin.log.debug(`(H)S Values: ${value}, ${this.cache.saturation}`);
+
+    try {
+      this.cache.hue = value;
+      if (this.cacheUpdated) {
+        let hexValue = colorsys.hsv2Hex(this.cache.hue, this.cache.saturation, 100);
+        hexValue = hexValue.replace("#", "");
+        this.plugin.log.info(hexValue);
+
+        await this.runActionList(WYZE_API_COLOR_PROPERTY, hexValue);
+        this.cacheUpdated = false;
+      } else {
+        this.cacheUpdated = true;
+      }
+      callback();
+    } catch (e) {
+      callback(e);
+    }
+  }
+
+  async setSaturation(value, callback) {
+    this.plugin.log.info(`Setting saturation (color) for ${this.homeKitAccessory.context.mac} to ${value}`);
+    this.plugin.log.debug(`H(S) Values: ${this.cache.saturation}, ${value}`);
+
+    try {
+      this.cache.saturation = value;
+      if (this.cacheUpdated) {
+        let hexValue = colorsys.hsv2Hex(this.cache.hue, this.cache.saturation, 100);
+        hexValue = hexValue.replace("#", "");
+        this.plugin.log.info(hexValue);
+
+        await this.runActionList(WYZE_API_COLOR_PROPERTY, hexValue);
+        this.cacheUpdated = false;
+      } else {
+        this.cacheUpdated = true;
+      }
+      callback();
+    } catch (e) {
+      callback(e);
+    }
+  }
+
+  _rangeToFloat(value, min, max) {
+    return (value - min) / (max - min);
+  }
+
+  _floatToRange(value, min, max) {
+    return Math.round((value * (max - min)) + min);
+  }
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -578,10 +578,10 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
-lodash@^4.17.14, lodash@^4.17.15:
-  version "4.17.15"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
-  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+lodash@^4.17.19:
+  version "4.17.19"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
+  integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
 
 md5@^2.2.1:
   version "2.2.1"


### PR DESCRIPTION
List of changes made in this pull request:

- Used @mda590's [fork](https://github.com/mda590/homebridge-wyze-connected-home/tree/add-color-bulb-support) of @misenhower's [original project](https://github.com/misenhower/homebridge-wyze-connected-home) as a base for added Color Bulb support.
- Added every change and commit done by @RMCob from initial fork through present day, creating parity with current plugin + Color Bulb support.
- Added @Chew's [pull request](https://github.com/misenhower/homebridge-wyze-connected-home/pull/40) on @misenhower's project to fix the recent 403 error issue related to userAgent.
- Updated Readme to explain that @RMCob's version of the plugin is the one being currently maintained, added Color Bulbs to list of supported devices, updated credits appropriately.
- Bumped version to 0.5.4 and made necessary Changelog updates.
- Bumped lodash version from 4.17.15 to 4.17.19.
- Bumped axios from version 0.19.2 to 0.21.1 to avoid severe vulnerability.